### PR TITLE
.gitignore updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /build
 /captures
 .externalNativeBuild
+[Tt]humbs.db


### PR DESCRIPTION
Windows image thumbnail exception added to .gitignore.
